### PR TITLE
Enable in-editor JSON search

### DIFF
--- a/components/CodeEditor/index.tsx
+++ b/components/CodeEditor/index.tsx
@@ -8,6 +8,8 @@ import 'brace/mode/javascript'
 
 import 'brace/theme/monokai'
 
+import 'brace/ext/searchbox';
+
 interface EditorProps {
   mode: 'jsx' | 'json' | 'javascript' | 'html'
   editorDomId: string


### PR DESCRIPTION
Referencing #4 

Hi @alexnm,

As I saw in the FAQ of the react-ace library, the way to enable the in-editor search is to add
`import 'brace/ext/searchbox';`

I don't know if we can rely only on the browser, as I see the editor currently doesn't render all the lines in the DOM, it renders only what is visible.